### PR TITLE
version bump from 20210216-3.1 to 20210910-3.1

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,13 +1,12 @@
 pkg_name=libedit
 pkg_origin=core
-pkg_version=3.1.20210216
+pkg_version=20210910-3.1
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=http://thrysoee.dk/editline/libedit-20210216-3.1.tar.gz
-pkg_dirname="${pkg_name}-20210216-3.1"
+pkg_source=http://thrysoee.dk/editline/${pkg_name}-${pkg_version}.tar.gz
 pkg_upstream_url="https://thrysoee.dk/editline/"
 pkg_description="This is an autotool- and libtoolized port of the NetBSD Editline library (libedit)."
-pkg_shasum=2283f741d2aab935c8c52c04b57bf952d02c2c02e651172f8ac811f77b1fc77a
+pkg_shasum=6792a6a992050762edcca28ff3318cdb7de37dccf7bc30db59fcd7017eed13c5
 pkg_deps=(core/glibc core/ncurses)
 pkg_build_deps=(core/gcc core/make core/coreutils)
 pkg_lib_dirs=(lib)


### PR DESCRIPTION
Issue: https://github.com/habitat-sh/core-plans/issues/4084
Signed-off-by: RaviDuddela <RaviShankar.Duddela@progress.com>